### PR TITLE
Fix memory issue with very large files.

### DIFF
--- a/src/file_service.py
+++ b/src/file_service.py
@@ -5,15 +5,9 @@ import os
 class FileService:
     @staticmethod
     def get_block_size(file_name):
-        chunks_limit = 1500  # incoming request payload size are restricted to 100kb
-        default_block_size = 4 * 1024 * 1024  # default chunk size of 4MB to get the most benefit out of deduplication
+        default_block_size = 10 * 1024 * 1024  # default chunk size of 4MB to get the most benefit out of deduplication
 
-        file_size = os.path.getsize(file_name)
-
-        if file_size / default_block_size > chunks_limit:
-            return int(round(file_size / chunks_limit))
-        else:
-            return default_block_size
+        return default_block_size
 
     @staticmethod
     def generate_etag(buf):

--- a/src/file_uploading.py
+++ b/src/file_uploading.py
@@ -25,7 +25,7 @@ class FileUploading:
         self.user = user
         self.auth_token = auth_token
         self.base_url = base_url
-        self.semaphore = BoundedSemaphore(2)
+        self.semaphore = BoundedSemaphore(8)
 
     def run(self):
         init()
@@ -39,7 +39,7 @@ class FileUploading:
         t.set_description("Uploading progress")
         count = itertools.count()
         try:
-            with ThreadPoolExecutor(max_workers=2) as executor:
+            with ThreadPoolExecutor(max_workers=4) as executor:
                 uploads = []
                 with open(self.file, 'rb') as infile:
                     buf = infile.read(block_size)

--- a/tests/test_file_service.py
+++ b/tests/test_file_service.py
@@ -6,26 +6,6 @@ from src.file_service import FileService
 
 class TestClass(unittest.TestCase):
 
-    @patch("os.path.getsize")
-    def test_block_size_should_be_default(self, getsize):
-        # mock
-        getsize.return_value = 128
-        default_block_size = 4 * 1024 * 1024
-
-        block_size = FileService.get_block_size("test")
-
-        self.assertEqual(default_block_size, block_size)
-
-    @patch("os.path.getsize")
-    def test_block_size_when_chunks_exceeded_limit(self, getsize):
-        # mock
-        getsize.return_value = 4 * 1024 * 1024 * 1024 * 1024
-        default_block_size = 4 * 1024 * 1024
-
-        block_size = FileService.get_block_size("test")
-
-        self.assertNotEqual(default_block_size, block_size)
-
     def test_generate_etag(self):
         expected_etag = 'a17c9aaa61e80a1bf71d0d850af4e5baa9800bbd-4'
 


### PR DESCRIPTION
* set static chunk size
* Increase number of workers
with 10 mb chunk size script memory consumption should be ~100mb. Tested on t2.micro with 500 gb file.