### PR TITLE
Added python-magic-bin==0.4.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ py==1.10.0
 Pygments==2.7.4
 pyparsing==2.4.7
 python-magic==0.4.18
+python-magic-bin==0.4.14
 readme-renderer==26.0
 requests==2.25.1
 requests-toolbelt==0.9.1


### PR DESCRIPTION
without python-magic-bin==0.4.14  getting error while installing