### PR TITLE
Updated client to support new APIs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ py==1.10.0
 Pygments==2.7.4
 pyparsing==2.4.7
 python-magic==0.4.18
-python-magic-bin==0.4.14
 readme-renderer==26.0
 requests==2.25.1
 requests-toolbelt==0.9.1

--- a/src/file_uploading.py
+++ b/src/file_uploading.py
@@ -38,6 +38,7 @@ class FileUploading:
         t = tqdm(total=expected_chunks, unit='B', unit_scale=False)
         t.set_description("Uploading progress")
         count = itertools.count()
+        upload_id = self.create_upload(self.base_url, auth, self.issue_key)
         try:
             with ThreadPoolExecutor(max_workers=4) as executor:
                 uploads = []
@@ -46,7 +47,7 @@ class FileUploading:
                     while len(buf) > 0:
                         self.semaphore.acquire()
                         try:
-                            future = executor.submit(self.process_chunk, self.base_url, auth, self.issue_key, buf, lock, t, count)
+                            future = executor.submit(self.process_chunk, self.base_url, auth, self.issue_key, buf, lock, t, count, upload_id)
                             uploads.append(future)
                             buf = infile.read(block_size)
                         except:
@@ -55,7 +56,7 @@ class FileUploading:
                         else:
                             future.add_done_callback(lambda x: self.semaphore.release())
                 chunk_list = [future.result() for future in futures.as_completed(uploads)]
-            self.create_file_chunked(self.base_url, auth, chunk_list, self.file, self.issue_key)
+            self.create_file_chunked(self.base_url, auth, chunk_list, self.file, self.issue_key, upload_id)
             t.update(1)
             t.close()
             click.echo('The file has been successfully uploaded and attached to the ticket %s' % self.issue_key)
@@ -67,51 +68,63 @@ class FileUploading:
             print(Fore.RED + "[ERROR] " + str(e))
             raise e
 
-    def process_chunk(self, base_url, auth, issue_key, buf, lock, progress, count):
-        index = next(count)
+    def process_chunk(self, base_url, auth, issue_key, buf, lock, progress, count, upload_id):
+        index = next(count) + 1
         etag = FileService.generate_etag(buf)
-        response = self.check_if_chunk_exists(base_url, auth, issue_key, [etag])
+        response = self.check_if_chunk_exists(base_url, auth, issue_key, [etag], upload_id)
         if not response["data"]["results"][etag]["exists"]:
-            self.upload_chunk(base_url, auth, issue_key, etag, buf)
+            self.upload_chunk(base_url, auth, issue_key, etag, buf, upload_id, index)
         with lock:
             progress.update(1)
         return etag, index
 
     @retry(wait_exponential_multiplier=1000, wait_exponential_max=5000, stop_max_attempt_number=5)
-    def create_file_chunked(self, base_url, auth, chunk_list, file, issue_key):
+    def create_file_chunked(self, base_url, auth, chunk_list, file, issue_key, upload_id):
         chunk_list.sort(key=itemgetter(1))
 
         etagList = []
         for n in chunk_list:
             etagList.append(n[0])
 
+        parameters = {'uploadId': upload_id}
         headers = {"Content-Type": "application/json"}
         response = requests.post(base_url + "/api/upload/" + issue_key + "/file/chunked",
                                  auth=auth,
                                  headers=headers,
                                  json={"chunks": self.__get_chunks_json(etagList),
                                        "name": os.path.basename(file),
-                                       "mimeType": from_file(file, mime=True)})
+                                       "mimeType": from_file(file, mime=True)}, params=parameters)
         self.__check_status_code(response.status_code)
         return response.json()
 
     @retry(wait_exponential_multiplier=100, wait_exponential_max=5000, stop_max_attempt_number=5)
-    def check_if_chunk_exists(self, base_url, auth, issue_key, chunk_list):
+    def check_if_chunk_exists(self, base_url, auth, issue_key, chunk_list, upload_id):
         headers = {"Content-Type": "application/json"}
+        parameters = {'uploadId': upload_id}
         response = requests.post(base_url + "/api/upload/" + issue_key + "/chunk/probe",
                                  auth=auth,
                                  headers=headers,
-                                 json={"chunks": self.__get_chunks_json(chunk_list)})
+                                 json={"chunks": self.__get_chunks_json(chunk_list)},
+                                 params=parameters)
         self.__check_status_code(response.status_code)
         return response.json()
 
     @retry(wait_exponential_multiplier=100, wait_exponential_max=5000, stop_max_attempt_number=5)
-    def upload_chunk(self, base_url, auth, issue_key, etag, buf):
+    def upload_chunk(self, base_url, auth, issue_key, etag, buf, upload_id, part_number):
+        parameters = {'uploadId': upload_id, 'partNumber': part_number}
         response = requests.post(base_url + "/api/upload/" + issue_key + "/chunk/" + etag,
                                  auth=auth,
                                  stream=True,
-                                 files={"chunk": io.BytesIO(buf)})
+                                 files={"chunk": io.BytesIO(buf)}, params=parameters)
         self.__check_status_code(response.status_code)
+
+    def create_upload(self, base_url, auth, issue_key):
+        headers = {"Content-Type": "application/json"}
+        response = requests.post(base_url + "/api/upload/" + issue_key,
+                                 auth=auth,
+                                 headers=headers)
+        self.__check_status_code(response.status_code)
+        return response.json()
 
     @staticmethod
     def __check_status_code(status_code):

--- a/tests/utils/mock_response.py
+++ b/tests/utils/mock_response.py
@@ -39,4 +39,7 @@ def mocked_request_500(*args, **kwargs):
         def json(self):
             return self.data
 
-    return MockResponse({}, 500)
+    if "/chunk" in args[0]:
+        return MockResponse({}, 500)
+    else:
+        return MockResponse({"upaload_id"}, 200)


### PR DESCRIPTION
Updated client to support upcoming changes in transfer.atlassian.com APIs. With the new APIs, we first have to generate the Upload Id and then use that upload id in every subsequent operation i.e. chunk probe and chunk upload. After uploading the chunks we have to create the file using the uploaded chunk ids. 