### PR TITLE
Updated Upload creation API

### DIFF
--- a/src/file_uploading.py
+++ b/src/file_uploading.py
@@ -38,7 +38,7 @@ class FileUploading:
         t = tqdm(total=expected_chunks, unit='B', unit_scale=False)
         t.set_description("Uploading progress")
         count = itertools.count()
-        upload_id = self.create_upload(self.base_url, auth, self.issue_key)
+        upload_id = self.create_upload(self.base_url, auth, self.issue_key)['uploadId']
         try:
             with ThreadPoolExecutor(max_workers=4) as executor:
                 uploads = []
@@ -120,7 +120,7 @@ class FileUploading:
 
     def create_upload(self, base_url, auth, issue_key):
         headers = {"Content-Type": "application/json"}
-        response = requests.post(base_url + "/api/upload/" + issue_key,
+        response = requests.post(base_url + "/api/upload/" + issue_key + "/create",
                                  auth=auth,
                                  headers=headers)
         self.__check_status_code(response.status_code)

--- a/tests/utils/mock_response.py
+++ b/tests/utils/mock_response.py
@@ -42,4 +42,4 @@ def mocked_request_500(*args, **kwargs):
     if "/chunk" in args[0]:
         return MockResponse({}, 500)
     else:
-        return MockResponse({"upaload_id"}, 200)
+        return MockResponse({"upaloadId": "upload_id"}, 200)

--- a/tests/utils/mock_response.py
+++ b/tests/utils/mock_response.py
@@ -25,6 +25,8 @@ def mocked_request(*args, **kwargs):
         etag = kwargs["json"]["chunks"][0]["hash"]
         size = kwargs["json"]["chunks"][0]["size"]
         return MockResponse({"data": {"results": {etag + "-" + size: {"exists": False}}}}, 200)
+    if "/api/upload/" in args[0]:
+        return MockResponse({"uploadId": "upload_id"}, 200)
     else:
         return MockResponse({}, 201)
 
@@ -42,4 +44,4 @@ def mocked_request_500(*args, **kwargs):
     if "/chunk" in args[0]:
         return MockResponse({}, 500)
     else:
-        return MockResponse({"upaloadId": "upload_id"}, 200)
+        return MockResponse({"uploadId": "upload_id"}, 200)


### PR DESCRIPTION
This change takes care of 
1. The change we recently updated the upload creation API to return uploadId as JSON instead of the string.
2. We updated the upload creation endpoint to avoid confusion with attachment upload endpoint