### PR TITLE
Updated the ETAG generation to use SHA256

### DIFF
--- a/src/file_service.py
+++ b/src/file_service.py
@@ -19,8 +19,8 @@ class FileService:
 
     @staticmethod
     def generate_etag(buf):
-        sha1 = hashlib.sha1()
-        sha1.update(buf)
-        etag = sha1.hexdigest() + "-" + str(len(buf))
+        sha256 = hashlib.sha256()
+        sha256.update(buf)
+        etag = sha256.hexdigest() + "-" + str(len(buf))
 
         return etag


### PR DESCRIPTION
Updated the ETAG generation to use SHA256 as Atlassian Attachment Management has deprecated the support for SHA1.  